### PR TITLE
Fix stray line in bad-iv helper

### DIFF
--- a/tests/helpers/bad-iv.js
+++ b/tests/helpers/bad-iv.js
@@ -17,4 +17,3 @@ try {
     process.exit(2);
   }
 }
-q;


### PR DESCRIPTION
## Summary
- remove stray `q;` line in `bad-iv.js`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d37020488327a6854a9061af4881