### PR TITLE
Fix package license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@fastify/cors": "^11.0.1",
     "dotenv": "^16.5.0",


### PR DESCRIPTION
## Summary
- update the project license field from ISC to MIT

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d44df46c8327bd7c6c960f7bd339