### PR TITLE
Set encryption key for test suite

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -7,6 +7,9 @@ import { buildApp } from '../src/app.js';
 
 // Set a unique DB path for each test run
 process.env.DB_FILE = `./test.${process.pid}.db`;
+// Provide a default encryption key for tests that don't specify one
+process.env.ENCRYPTION_KEY =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
 let app;
 
@@ -36,4 +39,5 @@ afterAll(async () => {
   try {
     fs.unlinkSync(process.env.DB_FILE);
   } catch {}
+  delete process.env.ENCRYPTION_KEY;
 });


### PR DESCRIPTION
## Summary
- set a deterministic encryption key in test bootstrap
- clean up key after the suite ends

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm install --silent` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6846d56c4eec8327b9395ae64bfad08d