### PR TITLE
Add PORT config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ A self-hostable Node.js service for managing encrypted license keys with expirat
 
 - Node.js 18+
 - SQLite (default, no setup required)
+
+### Environment Variables
+
+- `ENCRYPTION_KEY` (required): hex-encoded 32-byte key used for AES-256-GCM
+- `PORT` (optional): port Fastify listens on (default `3000`)

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,6 +21,7 @@ function requireEnv(key) {
 const config = {
   NODE_ENV: process.env.NODE_ENV || 'development',
   ENCRYPTION_KEY: requireEnv('ENCRYPTION_KEY'),
+  PORT: process.env.PORT || 3000,
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- add `PORT` to config
- document `PORT` and `ENCRYPTION_KEY` env vars

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d6edb5b48327b15cfb6ffeb3bd32