### PR TITLE
Fix DB close hook and cleanup tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -36,5 +36,9 @@ export async function buildApp() {
   await issueLicenseRoute(app);
   await verifyLicenseRoute(app);
 
+  app.addHook('onClose', async () => {
+    db.close();
+  });
+
   return app;
 }

--- a/tests/license.routes.test.js
+++ b/tests/license.routes.test.js
@@ -34,6 +34,9 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (app) {
+    await app.close();
+  }
   await fs.unlink(testDbFile).catch(() => {});
 });
 


### PR DESCRIPTION
## Summary
- close the SQLite connection when shutting down the app
- close Fastify in license route tests so DB files clean up correctly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e27fd49883279d6d9a53beda6964