### PR TITLE
Code cleanup and test setup fixes

### DIFF
--- a/sdk/lib/http.js
+++ b/sdk/lib/http.js
@@ -1,9 +1,5 @@
 // sdk/lib/http.js
 
-import fetch from 'node-fetch';
-
-// sdk/lib/http.js
-
 export async function fetchWithRetry(
   url,
   options = {},

--- a/src/app.js
+++ b/src/app.js
@@ -56,21 +56,5 @@ export async function buildApp() {
   return app;
 }
 
-// ✅ Start the server if not in test mode, or if in CI (GitHub Actions)
-if (process.env.NODE_ENV !== 'test' || process.env.CI === 'true') {
-  const PORT = process.env.PORT || 3001;
-  const start = async () => {
-    const app = await buildApp();
-    try {
-      await app.listen({ port: PORT, host: '0.0.0.0' });
-      app.log.info(`License API listening on port ${PORT}`);
-    } catch (err) {
-      app.log.error(err);
-      // ❗ Prevent process.exit in CI so tests can continue/fail gracefully
-      if (process.env.CI !== 'true') {
-        process.exit(1);
-      }
-    }
-  };
-  start();
-}
+// The server is started by index.js to avoid double initialization during
+// module imports. This file only exports the buildApp function.

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -7,6 +7,8 @@ import { buildApp } from '../src/app.js';
 
 // Set a unique DB path for each test run
 process.env.DB_FILE = `./test.${process.pid}.db`;
+// Use the same path for the better-sqlite3 connection
+process.env.DATABASE_FILE = process.env.DB_FILE;
 // Provide a default encryption key for tests that don't specify one
 process.env.ENCRYPTION_KEY =
   '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';


### PR DESCRIPTION
## Summary
- start server only from `index.js`
- ensure test database path is consistent
- rely on global `fetch` in SDK HTTP helper

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c48b027a88327bbe22b71fab4ef2f