### PR TITLE
Add build step with esbuild

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,12 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
+      - name: 🔨 Build
+        run: npm run build
+
       - name: 🚀 Start license server
         run: |
-          nohup node src/start.js > server.log 2>&1 &
+          nohup node dist/index.js > server.log 2>&1 &
 
       - name: ⏱ Wait for server to become available
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 dist/
+sdk/dist/
 coverage/
 .vitest/
 

--- a/README.md
+++ b/README.md
@@ -60,3 +60,14 @@ A self-hostable Node.js service for managing encrypted license keys with expirat
 - `ENCRYPTION_KEY` (required): hex-encoded 32-byte key used for AES-256-GCM
 - `JWT_SECRET` (required): secret used to sign license exports
 - `PORT` (optional): port Fastify listens on (default `3000`)
+
+## 🔨 Build
+
+Before starting the server or using the SDK run:
+
+```bash
+npm run build
+```
+
+This bundles the server (`index.js`) and SDK files into the `dist/` directory using esbuild.
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "start": "node index.js"
+    "start": "node index.js",
+    "build": "esbuild index.js --bundle --platform=node --format=esm --outdir=dist"
   },
   "keywords": [],
   "author": "",
@@ -27,6 +28,7 @@
     "execa": "^9.6.0",
     "nock": "^14.0.5",
     "node-fetch": "^3.3.2",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "esbuild": "^0.20.0"
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -11,7 +11,8 @@
     "casazium-license": "./cli.js"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "build": "esbuild client.js --bundle --platform=node --format=esm --outfile=dist/client.js && esbuild cli.js --bundle --platform=node --format=esm --outfile=dist/cli.js"
   },
   "keywords": [
     "license",
@@ -30,6 +31,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "vitest": "^1.0.0"
+    "vitest": "^1.0.0",
+    "esbuild": "^0.20.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import config from '../src/lib/config.js';
 import issueLicenseRoute from './routes/issue-license.js';
@@ -28,7 +29,7 @@ export async function buildApp() {
   const db = new Database(process.env.DATABASE_FILE || './dev.db');
   db.pragma('foreign_keys = ON');
 
-  const schemaPath = path.resolve('./src/db/schema.sql');
+  const schemaPath = fileURLToPath(new URL('../src/db/schema.sql', import.meta.url));
   const schemaSql = await fs.readFile(schemaPath, 'utf-8');
   db.exec(schemaSql);
 


### PR DESCRIPTION
## Summary
- add esbuild based build scripts
- ignore SDK build output
- document build step
- run build in CI
- update schema path for bundling

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611e7e6a6c83278f0a9e5d9dfbc64d